### PR TITLE
feat: enhance private key handling with type detection

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import { PrivateKey } from '@hashgraph/sdk';
 import axios from 'axios';
 import { Buffer } from 'buffer';
+import { detectKeyTypeFromString } from '@hashgraphonline/standards-sdk';
 
 export interface AuthConfig {
   accountId: string;
@@ -21,10 +22,17 @@ export class Auth {
 
   constructor(config: AuthConfig) {
     this.accountId = config.accountId;
-    this.privateKey =
-      typeof config.privateKey === 'string'
-        ? PrivateKey.fromStringED25519(config.privateKey)
-        : config.privateKey;
+    
+    // Handle both string and PrivateKey object inputs
+    if (typeof config.privateKey === 'string') {
+      // Use the key type detector to properly parse the string
+      const keyDetection = detectKeyTypeFromString(config.privateKey);
+      this.privateKey = keyDetection.privateKey;
+    } else {
+      // Already a PrivateKey object, use as-is
+      this.privateKey = config.privateKey;
+    }
+    
     this.network = config.network || 'mainnet';
     this.baseUrl = config.baseUrl || 'https://kiloscribe.com';
   }


### PR DESCRIPTION
---

## 🐛 Fix: Auth class incorrectly defaults to ED25519 for all string private keys

### Problem

The `Auth` class constructor in `@kiloscribe/inscription-sdk` has a critical bug where it assumes **all** string private keys are ED25519 format:

```typescript
// Before (BROKEN):
this.privateKey =
  typeof config.privateKey === 'string'
    ? PrivateKey.fromStringED25519(config.privateKey)  // ❌ Always assumes ED25519!
    : config.privateKey;
```

This causes failures for users with ECDSA keys:
- **ECDSA key users** → 💥 `Error: Invalid private key format`
- **ED25519 key users** → ✅ Works fine
- **PrivateKey object users** → ✅ Works fine

### Root Cause

The hardcoded `PrivateKey.fromStringED25519()` call doesn't account for Hedera's support of both ED25519 and ECDSA key types. 

### Solution

Updated the `Auth` constructor to use the `detectKeyTypeFromString` utility from `@hashgraphonline/standards-sdk`:

```typescript
// After (FIXED):
if (typeof config.privateKey === 'string') {
  // Use the key type detector to properly parse the string
  const keyDetection = detectKeyTypeFromString(config.privateKey);
  this.privateKey = keyDetection.privateKey;
} else {
  // Already a PrivateKey object, use as-is
  this.privateKey = config.privateKey;
}
```

### Impact

This fix:
- ✅ Properly detects and parses both ED25519 and ECDSA key strings
- ✅ Maintains backward compatibility for PrivateKey objects
- ✅ Aligns with the SDK's `executeTransaction` method behavior
- ✅ Prevents cryptographic failures from key type mismatches

### Testing

The fix has been validated with integration tests covering:
- ED25519 string keys
- ECDSA string keys  
- PrivateKey objects (both types)
- Profile inscription flows with both key types

### Breaking Changes

None. This is a backward-compatible bug fix that expands support to ECDSA keys without affecting existing ED25519 users.

